### PR TITLE
Fixing get_flow_by_id() returning objects in random order

### DIFF
--- a/bpmn_python/bpmn_diagram_rep.py
+++ b/bpmn_python/bpmn_diagram_rep.py
@@ -239,7 +239,7 @@ class BpmnDiagramGraph(object):
             flow_id (str): ID of flow.
 
         Returns:
-            tuple: Returns a 3-tuple, where the first value is the target_id, second value is source_id, third is a dictionary of all flow attributes.
+            tuple: Returns a 3-tuple, where the first value is the soureRef, second value is targetRef, third is a dictionary of all flow attributes.
         """
         tmp_flows = self.diagram_graph.edges(data=True)
         for flow in tmp_flows:

--- a/bpmn_python/bpmn_diagram_rep.py
+++ b/bpmn_python/bpmn_diagram_rep.py
@@ -239,7 +239,7 @@ class BpmnDiagramGraph(object):
             flow_id (str): ID of flow.
 
         Returns:
-            tuple: 3-tuple, where the first value is the target_id, second value is source_id, third is a dictionary of all flow attributes.
+            tuple: Returns a 3-tuple, where the first value is the target_id, second value is source_id, third is a dictionary of all flow attributes.
         """
         tmp_flows = self.diagram_graph.edges(data=True)
         for flow in tmp_flows:

--- a/bpmn_python/bpmn_diagram_rep.py
+++ b/bpmn_python/bpmn_diagram_rep.py
@@ -244,7 +244,7 @@ class BpmnDiagramGraph(object):
         tmp_flows = self.diagram_graph.edges(data=True)
         for flow in tmp_flows:
             if flow[2][consts.Consts.id] == flow_id:
-                return flow
+                return flow[2]['sourceRef'], flow[2]['targetRef'], flow[2]
 
     def get_flows_list_by_process_id(self, process_id: str) -> list:
         """


### PR DESCRIPTION
get_flow_by_id is returning a 3-tuple of (_ref1, _ref2, _flow_object) where one would assume that _ref woudl always be sourceRef and _ref2 would always be targetRef. But it returns the reference IDs in random order. This Patch fixes it.

